### PR TITLE
Fix compilation warning.

### DIFF
--- a/src/org/puremvc/objectivec/core/Controller.m
+++ b/src/org/puremvc/objectivec/core/Controller.m
@@ -10,6 +10,7 @@
 #import "View.h"
 #import "IObserver.h"
 #import "Observer.h"
+#import "ICommand.h"
 
 static id<IController> instance;
 
@@ -85,7 +86,7 @@ static id<IController> instance;
 	if (commandClassRef == nil) {
 		return;
 	}
-	[[[[commandClassRef alloc] init] autorelease] execute:notification];
+	[(id<ICommand>)[[[commandClassRef alloc] init] autorelease] execute:notification];
 }
 
 /**


### PR DESCRIPTION
Fix 'Instance method '-execute:' not found (return type defaults to 'id')
